### PR TITLE
Update to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ jar {
 	}
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/dragndrop.accesswidener")
+}
+
 // configure the maven publication
 publishing {
 	publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.14
+	minecraft_version=1.20
+	yarn_mappings=1.20+build.1
+	loader_version=0.14.22
 
 # Mod Properties
 	mod_version = 1.0.0
@@ -14,5 +14,5 @@ org.gradle.parallel=true
 	archives_base_name = drag-n-drop
 
 # Dependencies
-	fabric_version=0.74.0+1.19.3
+	fabric_version=0.83.0+1.20
 	mixinextras_version=0.2.0-beta.4

--- a/src/main/java/me/contaria/dragndrop/DraggableResourcePackEntry.java
+++ b/src/main/java/me/contaria/dragndrop/DraggableResourcePackEntry.java
@@ -4,13 +4,12 @@ import me.contaria.dragndrop.interfaces.IPackScreen;
 import me.contaria.dragndrop.mixin.EntryListWidgetAccessor;
 import me.contaria.dragndrop.mixin.ResourcePackEntryAccessor;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.ConfirmScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.pack.PackListWidget;
 import net.minecraft.client.gui.screen.pack.ResourcePackOrganizer;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.resource.ResourcePackCompatibility;
 import net.minecraft.text.Text;
 
@@ -23,8 +22,11 @@ public class DraggableResourcePackEntry extends PackListWidget.ResourcePackEntry
 
     private DelayedRenderCall delayedRenderCall;
 
+    private final Screen screen;
+
     public DraggableResourcePackEntry(MinecraftClient client, PackListWidget widget, Screen screen, ResourcePackOrganizer.Pack pack) {
-        super(client, widget, screen, pack);
+        super(client, widget, pack);
+        this.screen = screen;
     }
 
     @Override
@@ -50,18 +52,18 @@ public class DraggableResourcePackEntry extends PackListWidget.ResourcePackEntry
     }
 
     @Override
-    public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+    public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
         if (this.pickedUp) {
             this.delayedRenderCall = () -> {
                 int newY = y + mouseY - (int) this.pickedUpFromY + (int) (((ResourcePackEntryAccessor) this).getWidget().getScrollAmount() - this.scrollAmountWhenPickedUp);
                 int newX = x + mouseX - (int) this.pickedUpFromX;
 
-                DrawableHelper.fill(matrices, newX - 1, newY - 1, newX + entryWidth - 9, newY + entryHeight + 1, -1873784752);
-                super.render(matrices, index, newY, newX, entryWidth, entryHeight, mouseX, mouseY, false, tickDelta);
+                context.fill(newX - 1, newY - 1, newX + entryWidth - 9, newY + entryHeight + 1, -1873784752);
+                super.render(context, index, newY, newX, entryWidth, entryHeight, mouseX, mouseY, false, tickDelta);
             };
             return;
         }
-        super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, hovered, tickDelta);
+        super.render(context, index, y, x, entryWidth, entryHeight, mouseX, mouseY, hovered, tickDelta);
     }
 
     public void render() {

--- a/src/main/java/me/contaria/dragndrop/mixin/PackScreenMixin.java
+++ b/src/main/java/me/contaria/dragndrop/mixin/PackScreenMixin.java
@@ -41,9 +41,9 @@ public abstract class PackScreenMixin extends Screen implements IPackScreen {
         return this.selectedPackList == packListWidget;
     }
 
-    @Redirect(method = "method_29672", at = @At(value = "NEW", target = "Lnet/minecraft/client/gui/screen/pack/PackListWidget$ResourcePackEntry;"))
-    private PackListWidget.ResourcePackEntry dragndrop_replaceWithDraggableResourcePackEntries(MinecraftClient client, PackListWidget widget, Screen screen, ResourcePackOrganizer.Pack pack) {
-        return new DraggableResourcePackEntry(client, widget, screen, pack);
+    @Redirect(method = "method_29672", at = @At(value = "NEW", target = "(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/gui/screen/pack/PackListWidget;Lnet/minecraft/client/gui/screen/pack/ResourcePackOrganizer$Pack;)Lnet/minecraft/client/gui/screen/pack/PackListWidget$ResourcePackEntry;"))
+    private PackListWidget.ResourcePackEntry dragndrop_replaceWithDraggableResourcePackEntries(MinecraftClient client, PackListWidget widget, ResourcePackOrganizer.Pack pack) {
+        return new DraggableResourcePackEntry(client, widget, this, pack);
     }
 
     @Inject(method = "render", at = @At("TAIL"))

--- a/src/main/resources/dragndrop.accesswidener
+++ b/src/main/resources/dragndrop.accesswidener
@@ -1,0 +1,2 @@
+accessWidener   v2      named
+accessible      class   net/minecraft/client/gui/widget/EntryListWidget$Entry

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,6 +27,7 @@
   "mixins": [
     "dragndrop.mixins.json"
   ],
+  "accessWidener": "dragndrop.accesswidener",
 
   "depends": {
     "fabricloader": ">=0.14.14",


### PR DESCRIPTION
Access widener is needed, because `EntryListWidget.Entry` became protected.
[DrawableHelper was replaced with DrawContext](https://fabricmc.net/2023/05/25/120.html#screen-and-rendering-changes).
The redirect target was told to me by IDEA